### PR TITLE
fix(scoop): update ignition notes

### DIFF
--- a/bucket/ignition.json
+++ b/bucket/ignition.json
@@ -7,7 +7,7 @@
         "url": "https://inductiveautomation.com/ignition/license"
     },
     "notes": [
-        "If this is a version upgrade from 8.1.x to 8.2.x, run 'upgrade-ignition.bat' inside",
+        "If this is a version upgrade from 8.1.x to 8.2.x, run 'run-upgrader.bat' inside",
         "$dir before you start Ignition by running",
         "'start-ignition' on your terminal. To stop the Ignition service you may run",
         "'stop-ignition'."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The notes were incorrectly instructing the user to run the wrong _upgrader_ bat file.

This PR fixes that problem.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
