### PR TITLE
refactor(manifest): change cd alias to its full content

### DIFF
--- a/bucket/ignition.json
+++ b/bucket/ignition.json
@@ -12,7 +12,7 @@
         "# Install Ignition",
         "cmd.exe /c \"$dir\\install-ignition.bat\"",
         "# Run upgrader",
-        "cd \"$dir\" ; cmd.exe /c run-upgrader.bat",
+        "Set-Location \"$dir\" ; cmd.exe /c run-upgrader.bat",
         "# Start Ignition",
         "cmd.exe /c \"$dir\\start-ignition.bat\""
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

While editing the script in Visual Studio Code, I got the following warning:

>`cd` is an alias of `Set-Location`. Alias can introduce possible problems and make scripts hard to maintain.  Please consider changing alias to its full content. PSScriptAnalyzer(PSAvoidUsingCmdletAliases)

This PR changes the `cd` alias to its full content.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
