### PR TITLE
fix(ignition): use correct url and hash

### DIFF
--- a/bucket/ignition.json
+++ b/bucket/ignition.json
@@ -6,8 +6,8 @@
         "identifier": "Propietary",
         "url": "https://inductiveautomation.com/ignition/license"
     },
-    "url": "https://files.inductiveautomation.com/release/ia/8.1.22/20221101-1006/Ignition-macOs-x86-64-8.1.22.zip",
-    "hash": "352cae52f8c0b3298cb59d2efef8134cd0d1ab3d2bf613d9644c30dae54d0c80",
+    "url": "https://files.inductiveautomation.com/release/ia/8.1.22/20221101-1006/Ignition-windows-x86-64-8.1.22.zip",
+    "hash": "c85053dc9d6959b7ace8137861a0df3eeeedfea47705a6bc10d3ff1478e37bd9",
     "post_install": [
         "# Install Ignition",
         "cmd.exe /c \"$dir\\install-ignition.bat\"",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Use the correct `url` and `hash` for Windows ZIP file.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
