### PR TITLE
fix(coatl310): fix OSError when upgrading pip

### DIFF
--- a/bucket/coatl310.json
+++ b/bucket/coatl310.json
@@ -101,7 +101,6 @@
         "."
     ],
     "persist": [
-        "Scripts",
         "Lib\\site-packages"
     ],
     "checkver": {


### PR DESCRIPTION
https://github.com/ScoopInstaller/Main/issues/5090
