### PR TITLE
revert: fix OSError when upgrading pip

### DIFF
--- a/bucket/coatl310.json
+++ b/bucket/coatl310.json
@@ -101,6 +101,7 @@
         "."
     ],
     "persist": [
+        "Scripts",
         "Lib\\site-packages"
     ],
     "checkver": {


### PR DESCRIPTION
This reverts commit 0ed961f986f7305fae143861bd3d111c525a8e75.
