### PR TITLE
refactor(python2.7): fix path to chm file

### DIFF
--- a/bucket/python2.7.json
+++ b/bucket/python2.7.json
@@ -42,13 +42,17 @@
         "        -name \"(Default)\" -value \"$value\" -force | out-null",
         "}",
         "",
+        "$py_cleanVersion = $version -replace '\\.'",
         "$create_reg.Invoke(\"Python\\PythonCore\\2.7\\Help\\Main Python Documentation\", `",
         "    \"$dir\\Doc\\python$py_cleanVersion.chm\")",
         "$create_reg.Invoke(\"Python\\PythonCore\\2.7\\InstallPath\", `",
-        "    \"$dir\")",
+        "    \"$dir\\\")",
         "$create_reg.Invoke(\"Python\\PythonCore\\2.7\\InstallPath\\InstallGroup\", `",
         "    \"Python 2.7\")",
         "$create_reg.Invoke(\"Python\\PythonCore\\2.7\\PythonPath\", `",
         "    \"$dir;$dir\\Lib;$dir\\DLLs;$dir\\Lib\\lib-tk\")"
+    ],
+    "post_uninstall": [
+        "remove-item -path \"HKEY_CURRENT_USER\\Software\\Python\\PythonCore\\2.7\" -recurse"
     ]
 }


### PR DESCRIPTION
remove registry keys after uninstallation
